### PR TITLE
Always restore error handler

### DIFF
--- a/src/Subscriber/RobotsSubscriber.php
+++ b/src/Subscriber/RobotsSubscriber.php
@@ -247,9 +247,9 @@ final class RobotsSubscriber implements SubscriberInterface, EscargotAwareInterf
         try {
             $urls = new \SimpleXMLElement($content);
         } catch (\Exception $exception) {
-            restore_error_handler();
-
             return;
+        } finally {
+            restore_error_handler();
         }
 
         foreach ($urls as $url) {


### PR DESCRIPTION
In ef7d131f91224d4a74578b34aadefcf7496c3053 a custom error handler was introduced in order to be able to catch all errors and warnings when parsing XML using `SimpleXMLElement`. However, this error handler is never restored when no error happens - and thus replaces any other custom error handler from then on. This will then cause exceptions to be thrown for any error, warning, notice etc., even ones that are silenced with `@` (see https://github.com/contao/contao/pull/2894 for instance).

This PR moves `restore_error_handler()` to the `finally` block so that the error handler is always restored to the previous one.