### PR TITLE
Remove rel="nofollow" check

### DIFF
--- a/src/Subscriber/Util.php
+++ b/src/Subscriber/Util.php
@@ -50,11 +50,6 @@ class Util
             return false;
         }
 
-        // Skip rel="nofollow" links
-        if ($crawlUri->hasTag(HtmlCrawlerSubscriber::TAG_REL_NOFOLLOW)) {
-            return false;
-        }
-
         return true;
     }
 }

--- a/tests/Subscriber/UtilTest.php
+++ b/tests/Subscriber/UtilTest.php
@@ -48,12 +48,6 @@ class UtilTest extends TestCase
             false,
         ];
 
-        yield 'Current URI has a rel="nofollow" attribute' => [
-            (new CrawlUri(new Uri('https://www.terminal42.ch/foobar'), 1, false, new Uri('https://www.terminal42.ch')))->addTag(HtmlCrawlerSubscriber::TAG_REL_NOFOLLOW),
-            $this->createEscargot(),
-            false,
-        ];
-
         yield 'Current URI can be followed' => [
             new CrawlUri(new Uri('https://www.terminal42.ch/foobar'), 1, false, new Uri('https://www.terminal42.ch')),
             $this->createEscargot(),


### PR DESCRIPTION
The current interpretation of the `rel="nofollow"` attribute within Escargot is not correct. According to https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel#attr-nofollow / https://html.spec.whatwg.org/multipage/links.html#link-type-nofollow

> The [nofollow](https://html.spec.whatwg.org/multipage/links.html#link-type-nofollow) keyword indicates that the link is not endorsed by the original author or publisher of the page, or that the link to the referenced document was included primarily because of a commercial relationship between people affiliated with the two pages.

The attribute is not supposed to indicate that a page should not be crawled. Only that the target URI is not "endorsed" by the author of the originating document - and thus it can only serve as a hint for any crawler subscriber.

This PR removes the check from `Util::isAllowedToFollow` - but leaves the tagging of the URI in the `HtmlCrawlerSubscriber`.