### PR TITLE
Include query string in robots.txt check

### DIFF
--- a/src/Subscriber/RobotsSubscriber.php
+++ b/src/Subscriber/RobotsSubscriber.php
@@ -151,8 +151,14 @@ final class RobotsSubscriber implements SubscriberInterface, EscargotAwareInterf
 
         // Check if an URI is allowed by the robots.txt
         $inspector = new Inspector($robotsTxt, $this->escargot->getUserAgent());
+        $uri = $crawlUri->getUri();
+        $path = $uri->getPath();
+        
+        if ($query = $uri->getQuery()) {
+            $path .= '?'.$query;
+        }
 
-        if (!$inspector->isAllowed($crawlUri->getUri()->getPath())) {
+        if (!$inspector->isAllowed($path)) {
             $crawlUri->addTag(self::TAG_DISALLOWED_ROBOTS_TXT);
 
             $this->logWithCrawlUri(


### PR DESCRIPTION
In one Contao installation I added `disallow: /*?*` to the `robots.txt` in order to prevent the crawler from crawling any URL with a query parameter. However, the Crawler actually ignores that.

The issue is that in `RobotsSubscriber::handleDisallowedByRobotsTxtTag` only the URL _path_ gets passed to `Inspector::isAllowed`, which will disregard the query parameter outright:

https://github.com/terminal42/escargot/blob/1911148278a5cc3917d4a909ccf4433a27db6af3/src/Subscriber/RobotsSubscriber.php#L155

This PR adds the query parameter to the URL path so that such directives will be taken into account.