### PR TITLE
Add support for sitemapindex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 /.phpunit.result.cache
 /.php-cs-fixer.php
 /.php-cs-fixer.cache
+/.idea
+/.ddev

--- a/src/Subscriber/RobotsSubscriber.php
+++ b/src/Subscriber/RobotsSubscriber.php
@@ -253,6 +253,8 @@ final class RobotsSubscriber implements SubscriberInterface, EscargotAwareInterf
             restore_error_handler();
         }
 
+        $sitemapIndex = ('sitemapindex' === $urls->getName());
+
         foreach ($urls as $url) {
             // Add it to the queue if not present already
             try {
@@ -270,7 +272,10 @@ final class RobotsSubscriber implements SubscriberInterface, EscargotAwareInterf
                 continue;
             }
 
-            $this->escargot->addUriToQueue($uri, $sitemapUri);
+            $crawlUrl = $this->escargot->addUriToQueue($uri, $sitemapUri);
+            if ($sitemapIndex) {
+                $crawlUrl->addTag(self::TAG_IS_SITEMAP);
+            }
         }
     }
 

--- a/tests/Fixtures/scenario19/_description.txt
+++ b/tests/Fixtures/scenario19/_description.txt
@@ -1,0 +1,1 @@
+Here we test if the sitemap index is working.

--- a/tests/Fixtures/scenario19/_logs.txt
+++ b/tests/Fixtures/scenario19/_logs.txt
@@ -1,0 +1,1 @@
+[Terminal42\Escargot\Escargot] Finished crawling! Sent 4 request(s).

--- a/tests/Fixtures/scenario19/_requests.txt
+++ b/tests/Fixtures/scenario19/_requests.txt
@@ -1,0 +1,4 @@
+Successful request! URI: https://www.terminal42.ch/ (Level: 0, Processed: yes, Found on: root, Tags: none).
+Successful request! URI: https://www.terminal42.ch/sitemap.xml (Level: 2, Processed: yes, Found on: https://www.terminal42.ch/robots.txt, Tags: is-sitemap).
+Successful request! URI: https://www.terminal42.ch/sitemap_default.xml (Level: 3, Processed: yes, Found on: https://www.terminal42.ch/sitemap.xml, Tags: is-sitemap).
+Successful request! URI: https://www.terminal42.ch/foobar (Level: 4, Processed: yes, Found on: https://www.terminal42.ch/sitemap_default.xml, Tags: none).

--- a/tests/Fixtures/scenario19/foobar.txt
+++ b/tests/Fixtures/scenario19/foobar.txt
@@ -1,0 +1,11 @@
+https://www.terminal42.ch/foobar
+
+HTTP/2.0 200 OK
+content-type: text/html; charset=UTF-8
+
+<html>
+    <head>
+    </head>
+    <body>
+    </body>
+</html>

--- a/tests/Fixtures/scenario19/robots.txt
+++ b/tests/Fixtures/scenario19/robots.txt
@@ -1,0 +1,9 @@
+https://www.terminal42.ch/robots.txt
+
+HTTP/2.0 200 OK
+content-type: text/plain; charset=UTF-8
+
+User-agent: *
+Allow: /
+
+Sitemap: https://www.terminal42.ch/sitemap.xml

--- a/tests/Fixtures/scenario19/root.txt
+++ b/tests/Fixtures/scenario19/root.txt
@@ -1,0 +1,11 @@
+https://www.terminal42.ch/
+
+HTTP/2.0 200 OK
+content-type: text/html; charset=UTF-8
+
+<html>
+<head>
+</head>
+<body>
+</body>
+</html>

--- a/tests/Fixtures/scenario19/sitemap.txt
+++ b/tests/Fixtures/scenario19/sitemap.txt
@@ -1,0 +1,10 @@
+https://www.terminal42.ch/sitemap.xml
+
+HTTP/2.0 200 OK
+content-type: application/xml
+
+<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+    <sitemap>
+        <loc>https://www.terminal42.ch/sitemap_default.xml</loc>
+    </sitemap>
+</sitemapindex>

--- a/tests/Fixtures/scenario19/sitemap_default.txt
+++ b/tests/Fixtures/scenario19/sitemap_default.txt
@@ -1,0 +1,9 @@
+https://www.terminal42.ch/sitemap_default.xml
+
+HTTP/2.0 200 OK
+content-type: application/xml
+
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
+  <url><loc>https://www.terminal42.ch/foobar</loc></url>
+</urlset>


### PR DESCRIPTION
This PR add support for sitemap index files.

Currently escargot do not index page on sitemaps added via sitemap indexes. But for page with more than 50.000 entries in a sitemap google recommends split sitemaps and add them to a sitemap index: https://developers.google.com/search/docs/crawling-indexing/sitemaps/large-sitemaps