### PR TITLE
Add psr/log 2.0 and 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-simplexml": "*",
         "nyholm/psr7": "^1.1",
         "psr/http-message": "^1.0",
-        "psr/log": "^1.1 || ^2.0",
+        "psr/log": "^1.1 || ^2.0 || ^3.0",
         "symfony/dom-crawler": "^4.4 || ^5.0 || ^6.0",
         "symfony/event-dispatcher": "^4.4 || ^5.0 || ^6.0",
         "symfony/http-client": "^4.4 || ^5.0 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,8 @@
     "require-dev": {
         "doctrine/dbal": "^2.13 || ^3.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0",
-        "symfony/phpunit-bridge": "^5.1.8 || ^6.0"
+        "symfony/phpunit-bridge": "^5.1.8 || ^6.0",
+        "colinodell/psr-testlogger": "^1.1"
     },
     "config": {
         "preferred-install": {

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "doctrine/dbal": "^2.13 || ^3.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0",
         "symfony/phpunit-bridge": "^5.1.8 || ^6.0",
-        "colinodell/psr-testlogger": "^1.1"
+        "fig/log-test": "^1.0"
     },
     "config": {
         "preferred-install": {

--- a/composer.json
+++ b/composer.json
@@ -20,13 +20,14 @@
         "ext-simplexml": "*",
         "nyholm/psr7": "^1.1",
         "psr/http-message": "^1.0",
-        "psr/log": "^1.1 || ^2.0",
+        "psr/log": "^1.1 || ^2.0 || ^3.0",
         "symfony/dom-crawler": "^4.4 || ^5.0 || ^6.0",
         "symfony/event-dispatcher": "^4.4 || ^5.0 || ^6.0",
         "symfony/http-client": "^4.4 || ^5.0 || ^6.0",
         "webignition/robots-txt-file": "^3.0"
     },
     "require-dev": {
+        "beste/psr-testlogger": "^1.0",
         "doctrine/dbal": "^2.13 || ^3.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0",
         "symfony/phpunit-bridge": "^5.1.8 || ^6.0"

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "webignition/robots-txt-file": "^3.0"
     },
     "require-dev": {
-        "beste/psr-testlogger": "^1.0",
         "doctrine/dbal": "^2.13 || ^3.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0",
         "symfony/phpunit-bridge": "^5.1.8 || ^6.0",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-simplexml": "*",
         "nyholm/psr7": "^1.1",
         "psr/http-message": "^1.0",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1 || ^2.0",
         "symfony/dom-crawler": "^4.4 || ^5.0 || ^6.0",
         "symfony/event-dispatcher": "^4.4 || ^5.0 || ^6.0",
         "symfony/http-client": "^4.4 || ^5.0 || ^6.0",

--- a/tests/EscargotTest.php
+++ b/tests/EscargotTest.php
@@ -12,13 +12,13 @@ declare(strict_types=1);
 
 namespace Terminal42\Escargot\Tests;
 
-use ColinODell\PsrTestLogger\TestLogger;
 use Nyholm\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
+use Psr\Log\Test\TestLogger;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Contracts\HttpClient\ChunkInterface;

--- a/tests/EscargotTest.php
+++ b/tests/EscargotTest.php
@@ -12,13 +12,13 @@ declare(strict_types=1);
 
 namespace Terminal42\Escargot\Tests;
 
+use ColinODell\PsrTestLogger\TestLogger;
 use Nyholm\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
-use Psr\Log\Test\TestLogger;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Contracts\HttpClient\ChunkInterface;


### PR DESCRIPTION
Currently the `psr/log` dependency is set to `^1.1` Another package I want to use has it set to `^2.0`. Unfortunately, this causes conflicts. Therefore, I propose to allow `^2.0` here as well. The signatures look identical, the tests ran through and the standard should also have no changes.

Or are there any reasons for `^1.1` that I don't see?