### PR TITLE
Allow version 2 of psr/http-message

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^7.4 || ^8.0",
         "ext-simplexml": "*",
         "nyholm/psr7": "^1.1",
-        "psr/http-message": "^1.0",
+        "psr/http-message": "^1.0 || ^2.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "symfony/dom-crawler": "^4.4 || ^5.0 || ^6.0",
         "symfony/event-dispatcher": "^4.4 || ^5.0 || ^6.0",


### PR DESCRIPTION
I didn‘t check if all the return types actually match, but since the same types were already annotated in version 1, there should be no surprises.